### PR TITLE
perf: decrease allocations based on base

### DIFF
--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -1,0 +1,33 @@
+package huffman
+
+import (
+	"fmt"
+	"math/rand"
+	"testing"
+)
+
+func BenchmarkLabel(b *testing.B) {
+	bases := []int{2, 8, 32}
+	numItems := []int{10, 100, 1000}
+
+	for _, base := range bases {
+		for _, numItem := range numItems {
+			name := fmt.Sprintf("base=%d/numItems=%d", base, numItem)
+			b.Run(name, func(b *testing.B) {
+				freqs := make([]int, numItem)
+				for i := range freqs {
+					freqs[i] = rand.Intn(100)
+				}
+
+				b.ResetTimer()
+
+				for i := 0; i < b.N; i++ {
+					got := Label(base, freqs)
+					if len(got) != len(freqs) {
+						b.Fatalf("unexpected length: got=%d, want=%d", len(got), len(freqs))
+					}
+				}
+			})
+		}
+	}
+}

--- a/huffman_test.go
+++ b/huffman_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"pgregory.net/rapid"
 )
 
@@ -165,6 +166,26 @@ func TestLabel_rapid(t *testing.T) {
 			})
 		})
 	}
+}
+
+func TestLabel_rapid_arbitraryBases(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		base := rapid.IntRange(2, 100).Draw(t, "base")
+		freqs := rapid.SliceOf(rapid.Int()).Draw(t, "freqs")
+		labels := Label(base, freqs)
+
+		// Not checking all the invariants here.
+		// We just want to verify that it doesn't panic
+		// on random bases and frequencies.
+		require.Len(t, labels, len(freqs), "number of labels did not match")
+
+		var seen [][]int
+		for _, label := range labels {
+			assert.NotEmpty(t, label, "label must not be empty")
+			assert.NotContains(t, seen, label, "duplicate label %v", label)
+			seen = append(seen, label)
+		}
+	})
 }
 
 func assertLabelInvariants(t assert.TestingT, numItems int, labels []string) bool {


### PR DESCRIPTION
There are two heavy sources of allocations based on value of base:

1. each node in the tree causes an allocation
2. the list of children for each node causes an allocation

The allocation for (1) can be batched into a single allocation
because we can pre-calculate the exact number of nodes we'll need.

The allocation for (2) can be eliminated
by tracking parent indexes in a list of nodes
instead of a slice of child nodes.

This change performs both these optimizations.

```
goos: darwin
goarch: arm64
pkg: go.abhg.dev/algorithm/huffman
cpu: Apple M3
                              │  before.txt  │              after.txt              │
                              │    sec/op    │   sec/op     vs base                │
Label/base=2/numItems=10-8       1.220µ ± 3%   1.017µ ± 4%  -16.64% (p=0.000 n=10)
Label/base=2/numItems=100-8      15.12µ ± 0%   14.93µ ± 1%   -1.24% (p=0.000 n=10)
Label/base=2/numItems=1000-8     226.5µ ± 1%   240.0µ ± 0%   +5.97% (p=0.000 n=10)
Label/base=8/numItems=10-8       765.8n ± 1%   516.0n ± 3%  -32.61% (p=0.000 n=10)
Label/base=8/numItems=100-8      8.691µ ± 1%   7.946µ ± 1%   -8.57% (p=0.000 n=10)
Label/base=8/numItems=1000-8     120.7µ ± 0%   128.1µ ± 1%   +6.15% (p=0.000 n=10)
Label/base=32/numItems=10-8      675.4n ± 1%   424.5n ± 2%  -37.15% (p=0.000 n=10)
Label/base=32/numItems=100-8     7.629µ ± 1%   6.463µ ± 1%  -15.28% (p=0.000 n=10)
Label/base=32/numItems=1000-8   113.41µ ± 0%   98.98µ ± 1%  -12.72% (p=0.000 n=10)
geomean                          10.78µ        9.299µ       -13.71%

                              │  before.txt   │              after.txt               │
                              │     B/op      │     B/op      vs base                │
Label/base=2/numItems=10-8       2.062Ki ± 5%   1.508Ki ± 4%  -26.89% (p=0.000 n=10)
Label/base=2/numItems=100-8      23.73Ki ± 2%   21.74Ki ± 2%   -8.36% (p=0.000 n=10)
Label/base=2/numItems=1000-8     294.3Ki ± 0%   325.1Ki ± 0%  +10.45% (p=0.000 n=10)
Label/base=8/numItems=10-8        1224.0 ± 0%     760.0 ± 0%  -37.91% (p=0.000 n=10)
Label/base=8/numItems=100-8      13.97Ki ± 0%   10.15Ki ± 1%  -27.35% (p=0.000 n=10)
Label/base=8/numItems=1000-8     144.0Ki ± 0%   119.0Ki ± 1%  -17.37% (p=0.000 n=10)
Label/base=32/numItems=10-8       1112.0 ± 0%     712.0 ± 0%  -35.97% (p=0.000 n=10)
Label/base=32/numItems=100-8    12.062Ki ± 0%   8.242Ki ± 0%  -31.67% (p=0.000 n=10)
Label/base=32/numItems=1000-8   120.74Ki ± 0%   83.27Ki ± 0%  -31.03% (p=0.000 n=10)
geomean                          15.60Ki        11.84Ki       -24.14%

                              │ before.txt  │              after.txt              │
                              │  allocs/op  │  allocs/op   vs base                │
Label/base=2/numItems=10-8       55.00 ± 4%    36.00 ± 3%  -34.55% (p=0.000 n=10)
Label/base=2/numItems=100-8      457.0 ± 1%    418.0 ± 1%   -8.53% (p=0.000 n=10)
Label/base=2/numItems=1000-8    4.561k ± 0%   5.016k ± 0%   +9.96% (p=0.000 n=10)
Label/base=8/numItems=10-8       38.00 ± 0%    17.00 ± 0%  -55.26% (p=0.000 n=10)
Label/base=8/numItems=100-8      339.0 ± 2%    245.0 ± 0%  -27.73% (p=0.000 n=10)
Label/base=8/numItems=1000-8    2.929k ± 0%   3.072k ± 0%   +4.88% (p=0.000 n=10)
Label/base=32/numItems=10-8      35.00 ± 0%    14.00 ± 0%  -60.00% (p=0.000 n=10)
Label/base=32/numItems=100-8     314.0 ± 0%    181.0 ± 0%  -42.36% (p=0.000 n=10)
Label/base=32/numItems=1000-8   3.093k ± 0%   2.041k ± 0%  -34.01% (p=0.000 n=10)
geomean                          375.1         257.6       -31.33%
```